### PR TITLE
deactivate XHR Polling for the websockets

### DIFF
--- a/app/context/StompContext.tsx
+++ b/app/context/StompContext.tsx
@@ -16,7 +16,7 @@ export function StompProvider({ children }: { children: ReactNode }) {
     catch { /* no token */ }
 
     const stompClient = new Client({
-      webSocketFactory: () => new SockJS(`${getApiDomain()}/ws`, null, { transports: ["xhr-polling"] }),
+      webSocketFactory: () => new SockJS(`${getApiDomain()}/ws`),
       connectHeaders: { token },
       reconnectDelay: 5000,
       onStompError: (frame) => console.error("STOMP error", frame),


### PR DESCRIPTION
This pull request makes a small change to the `StompProvider` in `StompContext.tsx` by removing the `transports: ["xhr-polling"]` option from the `SockJS` client configuration. This simplifies the WebSocket setup and allows SockJS to use its default transport selection.

* [`app/context/StompContext.tsx`](diffhunk://#diff-12b165199defa36d80e6849697cb2e0cc51a7e708cac93205b83f61686741ec6L19-R19): Removed the explicit `transports: ["xhr-polling"]` option from the `SockJS` initialization in the `StompProvider` component.