### PR TITLE
85 fe flow control and refactor

### DIFF
--- a/app/components/LyricsDisplay.tsx
+++ b/app/components/LyricsDisplay.tsx
@@ -138,8 +138,6 @@ const LyricsBlock: FC<{ lyrics: string }> = ({ lyrics }) => (
       height: "65vh",
       overflowY: "auto",
       padding: "24px 40px 40px",
-      scrollbarWidth: "thin",
-      scrollbarColor: "#FF2D7E transparent",
     }}
   >
     <Paragraph

--- a/app/components/SessionSidebar.tsx
+++ b/app/components/SessionSidebar.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Layout, Button, Typography, Tooltip, Badge, Avatar, Space } from "antd";
+import { DeleteOutlined, PlusOutlined, UserOutlined } from "@ant-design/icons";
+import { Song } from "@/types/song";
+import { Participant } from "@/types/session";
+
+const { Text } = Typography;
+
+interface SessionSidebarProps {
+  queue: Song[];
+  currentSong: Song | null;
+  participants: Participant[];
+  isAdmin: boolean;
+  userId: string;
+  onAddSong: () => void;
+  onDeleteSong: (songId: number) => void;
+  onSkipSong: () => void;
+}
+
+export default function SessionSidebar({ queue, currentSong, participants, isAdmin, userId, onAddSong, onDeleteSong, onSkipSong }: SessionSidebarProps) {
+  return (
+    <Layout.Sider
+      width={320}
+      style={{
+        background: "#1A1A2E",
+        borderLeft: "1px solid rgba(255, 255, 255, 0.1)",
+      }}
+    >
+      <div style={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
+
+        {/* ── Queue section (70%) ── */}
+        <div style={{ flex: "7 1 0", minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+          <div style={{ padding: "24px 24px 0 24px", flexShrink: 0 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+              <Text style={{ color: "#FFFFFF", fontWeight: 600, fontSize: 15 }}>
+                Party Playlist <Badge count={queue.length} style={{ backgroundColor: "#FF2D7E" }} />
+              </Text>
+              <Space size={8}>
+                {isAdmin && (
+                  <Tooltip title={queue.length === 0 && !currentSong ? "No songs in queue" : "Skip Song"}>
+                    <Button
+                      type="primary"
+                      disabled={queue.length === 0 && !currentSong}
+                      size="small"
+                      style={{ background: "#1DB954", borderColor: "#1DB954" }}
+                      onClick={onSkipSong}
+                    >
+                      Skip
+                    </Button>
+                  </Tooltip>
+                )}
+                <Button type="primary" size="small" icon={<PlusOutlined />} onClick={onAddSong}>
+                  Add Song
+                </Button>
+              </Space>
+            </div>
+          </div>
+
+          <div style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: "0 24px 12px 24px" }}>
+            {currentSong && (
+              <div style={{ background: "#0D0D1A", borderRadius: 8, border: "1px solid rgba(255, 45, 126, 0.4)", marginBottom: 8, padding: "10px 12px", display: "flex", alignItems: "center", gap: 10 }}>
+                <div>
+                  <div style={{ color: "#FF2D7E", fontSize: 13, fontWeight: 600 }}>{currentSong.title}</div>
+                  <div style={{ color: "rgba(255, 45, 126, 0.6)", fontSize: 12 }}>
+                    {currentSong.artist}{currentSong.addedBy && <span style={{ marginLeft: 6, opacity: 0.7 }}>· 🎤 {currentSong.addedBy.username}</span>}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {queue.length === 0 ? (
+              <Text style={{ color: "rgba(255,255,255,0.3)" }}>No songs yet</Text>
+            ) : (
+              queue.map((song: Song) => (
+                <div
+                  key={song.id}
+                  style={{ background: "#0D0D1A", borderRadius: 8, border: "1px solid rgba(255,255,255,0.08)", marginBottom: 8, padding: "10px 12px", display: "flex", alignItems: "center", gap: 10 }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ color: "#FFFFFF", fontSize: 13 }}>{song.title}</div>
+                    <div style={{ color: "rgba(255,255,255,0.5)", fontSize: 12 }}>
+                      {song.artist}{song.addedBy && <span style={{ marginLeft: 6, opacity: 0.7 }}>· 🎤 {song.addedBy.username}</span>}
+                    </div>
+                  </div>
+                  {isAdmin && (
+                    <Tooltip title="Remove song">
+                      <Button
+                        type="text"
+                        size="small"
+                        icon={<DeleteOutlined />}
+                        onClick={() => onDeleteSong(song.id)}
+                        style={{ color: "rgba(255,80,80,0.7)", flexShrink: 0 }}
+                      />
+                    </Tooltip>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* ── Participants section (30%) ── */}
+        <div
+          style={{
+            flex: "3 1 0",
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+            borderTop: "1px solid rgba(255, 255, 255, 0.1)",
+          }}
+        >
+          <div style={{ padding: "12px 24px 0 24px", flexShrink: 0 }}>
+            <Text style={{ color: "#FFFFFF", fontWeight: 600, fontSize: 15, display: "block", marginBottom: 12 }}>
+              Party People <Badge count={participants.length} style={{ backgroundColor: "#00C2FF" }} />
+            </Text>
+          </div>
+
+          <div style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: "0 24px 24px 24px" }}>
+            {participants.length === 0 ? (
+              <Text style={{ color: "rgba(255,255,255,0.3)" }}>No one here yet</Text>
+            ) : (
+              participants.map((p) => (
+                <div
+                  key={p.id}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    marginBottom: 8,
+                    padding: "6px 8px",
+                    borderRadius: 8,
+                    background: String(p.id) === String(userId) ? "rgba(0, 194, 255, 0.08)" : "transparent",
+                  }}
+                >
+                  <Avatar size={28} icon={<UserOutlined />} style={{ background: "rgba(0, 194, 255, 0.3)", flexShrink: 0 }} />
+                  <Text style={{ color: "#FFFFFF", fontSize: 13 }}>
+                    {p.username}
+                    {String(p.id) === String(userId) && (
+                      <span style={{ color: "#00C2FF", marginLeft: 6, fontSize: 11 }}>
+                        {isAdmin ? "(host)" : "(you)"}
+                      </span>
+                    )}
+                  </Text>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+      </div>
+    </Layout.Sider>
+  );
+}

--- a/app/components/SongSearchContent.tsx
+++ b/app/components/SongSearchContent.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useApi } from "@/hooks/useApi";
-import { SongSearchResult } from "@/types/song";
-import { Input, Avatar, Empty, App } from "antd";
+import { Input, Avatar, Empty } from "antd";
 import { SearchOutlined, PlusOutlined, WarningOutlined } from "@ant-design/icons";
+import { useSongSearch } from "@/hooks/useSongSearch";
 
 const { Search } = Input;
 
@@ -14,62 +12,7 @@ interface SongSearchContentProps {
 }
 
 export default function SongSearchContent({ sessionId, onSongAdded }: SongSearchContentProps) {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<SongSearchResult[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const { notification } = App.useApp();
-  const apiService = useApi();
-
-  useEffect(() => {
-    const query = searchQuery.trim();
-    if (!query) {
-      setSearchResults([]);
-      return;
-    }
-
-    const timeout = setTimeout(async () => {
-      setIsLoading(true);
-      try {
-        const params = new URLSearchParams({ query });
-        const data = await apiService.get<SongSearchResult[]>(`/songs/search?${params}`);
-        setSearchResults(data);
-      } catch {
-        notification.error({
-          title: "Search failed",
-          description: "Could not reach the server.",
-        });
-        setSearchResults([]);
-      } finally {
-        setIsLoading(false);
-      }
-    }, 300);
-
-    return () => clearTimeout(timeout);
-  }, [searchQuery, notification, apiService]);
-
-  const handleAddSong = async (song: SongSearchResult) => {
-    try {
-      await apiService.post(`/sessions/${sessionId}/songs`, {
-        spotifyId: song.spotifyId,
-        title: song.title,
-        artist: song.artist,
-        durationMs: song.durationMs,
-      });
-      notification.success({
-        title: "Song Added",
-        description: `"${song.title}" by ${song.artist} has been added to the queue.`,
-        placement: "bottomRight",
-      });
-      setSearchQuery("");
-      setSearchResults([]);
-      onSongAdded();
-    } catch {
-      notification.error({
-        title: "Failed to add song",
-        description: "Could not add the song to the queue.",
-      });
-    }
-  };
+  const { searchQuery, setSearchQuery, searchResults, isLoading, handleAddSong } = useSongSearch(sessionId, onSongAdded);
 
   const showEmpty = !isLoading && !!searchQuery.trim() && searchResults.length === 0;
   const showResults = !isLoading && searchResults.length > 0;

--- a/app/components/SongSearchDrawer.tsx
+++ b/app/components/SongSearchDrawer.tsx
@@ -1,83 +1,23 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useApi } from "@/hooks/useApi";
-import { SongSearchResult } from "@/types/song";
-import { Drawer, Input, Empty, Avatar, App } from "antd";
+import { Drawer, Input, Empty, Avatar } from "antd";
 import { SearchOutlined, PlusOutlined, WarningOutlined } from "@ant-design/icons";
+import { useSongSearch } from "@/hooks/useSongSearch";
 
 const { Search } = Input;
 
 interface SongSearchDrawerProps {
   open: boolean;
   onClose: () => void;
-  onAddSong: (song: SongSearchResult) => void;
+  onAddSong: () => void;
   sessionId: string;
 }
 
 export default function SongSearchDrawer({ open, onClose, onAddSong, sessionId }: SongSearchDrawerProps) {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<SongSearchResult[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const { notification } = App.useApp();
-  const apiService = useApi();
-
-  useEffect(() => {
-    const query = searchQuery.trim();
-
-    if (!query) {
-      setSearchResults([]);
-      return;
-    }
-
-    const timeout = setTimeout(async () => {
-      setIsLoading(true);
-      try {
-        const params = new URLSearchParams({ query });
-        const data = await apiService.get<SongSearchResult[]>(`/songs/search?${params}`);
-        setSearchResults(data);
-      } catch {
-        notification.error({
-          title: "Search failed",
-          description: "Could not reach the server.",
-        });
-        setSearchResults([]);
-      } finally {
-        setIsLoading(false);
-      }
-    }, 300);
-
-    return () => clearTimeout(timeout);
-  }, [searchQuery, notification, apiService]);
-
-  const handleAddSong = async (song: SongSearchResult) => {
-    try {
-      await apiService.post(`/sessions/${sessionId}/songs`, {
-        spotifyId: song.spotifyId,
-        title: song.title,
-        artist: song.artist,
-        durationMs: song.durationMs,
-      });
-
-      onAddSong(song);
-      notification.success({
-        title: "Song Added",
-        description: `"${song.title}" by ${song.artist} has been added to the queue.`,
-        placement: "bottomRight",
-      });
-      setSearchQuery("");
-      setSearchResults([]);
-    } catch {
-      notification.error({
-        title: "Failed to add song",
-        description: "Could not add the song to the queue.",
-      });
-    }
-  };
+  const { searchQuery, setSearchQuery, searchResults, isLoading, handleAddSong } = useSongSearch(sessionId, onAddSong);
 
   const handleClose = () => {
     setSearchQuery("");
-    setSearchResults([]);
     onClose();
   };
 

--- a/app/components/VotingPhase.tsx
+++ b/app/components/VotingPhase.tsx
@@ -94,6 +94,7 @@ export default function VotingPhase({
   const timerPercent = secondsLeft !== null && totalSeconds ? (secondsLeft / totalSeconds) * 100 : 0;
   const timerColor = secondsLeft !== null && secondsLeft <= 10 ? "#FF2D7E" : "#00C2FF";
   const sortedCandidates = [...candidates].sort((a, b) => (b.currentVoteCount ?? 0) - (a.currentVoteCount ?? 0));
+  const winnerSong = currentSong ?? sortedCandidates[0] ?? null;
 
   // Winner screen
   if (showWinner) {
@@ -118,7 +119,7 @@ export default function VotingPhase({
           Next up...
         </Title>
 
-        {currentSong && (
+        {winnerSong && (
           <div
             style={{
               background: "linear-gradient(135deg, #FF2D7E 0%, #C91F5E 100%)",
@@ -130,9 +131,9 @@ export default function VotingPhase({
               boxShadow: "0 0 60px rgba(255, 45, 126, 0.4)",
             }}
           >
-            {currentSong.albumArt && (
+            {winnerSong.albumArt && (
               <Image
-                src={currentSong.albumArt}
+                src={winnerSong.albumArt}
                 alt="album art"
                 width={120}
                 height={120}
@@ -140,19 +141,19 @@ export default function VotingPhase({
               />
             )}
             <Title level={2} style={{ color: "#FFFFFF", margin: 0 }}>
-              {currentSong.title}
+              {winnerSong.title}
             </Title>
             <Text style={{ color: "rgba(255,255,255,0.8)", fontSize: 16 }}>
-              {currentSong.artist}
+              {winnerSong.artist}
             </Text>
-            {currentSong.addedBy && (
+            {winnerSong.addedBy && (
               <Text style={{ color: "rgba(255,255,255,0.7)", fontSize: 15, display: "block", marginTop: 12 }}>
-                🎤 {currentSong.addedBy.username}
+                🎤 {winnerSong.addedBy.username}
               </Text>
             )}
             <div style={{ marginTop: 8 }}>
               <Text style={{ color: "rgba(255,255,255,0.6)", fontSize: 14 }}>
-                {currentSong.currentVoteCount ?? 0} votes
+                {winnerSong.currentVoteCount ?? 0} votes
               </Text>
             </div>
           </div>

--- a/app/components/VotingPhase.tsx
+++ b/app/components/VotingPhase.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Alert, Button, Progress, Typography } from "antd";
+import { Alert, Badge, Button, Card, Progress, Typography } from "antd";
+import { TrophyOutlined } from "@ant-design/icons";
 import { useApi } from "@/hooks/useApi";
 import { VotingRound } from "@/types/voting";
 import { Song } from "@/types/song";
@@ -15,12 +16,14 @@ interface VotingPhaseProps {
   sessionId: string;
   round: VotingRound;
   onRoundClosed: () => void;
+  currentSong: Song | null;
 }
 
 export default function VotingPhase({
   sessionId,
   round,
   onRoundClosed,
+  currentSong,
 }: VotingPhaseProps) {
   const apiService = useApi();
 
@@ -31,22 +34,20 @@ export default function VotingPhase({
   const [error, setError] = useState<string | null>(null);
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
   const [totalSeconds, setTotalSeconds] = useState<number | null>(null);
-  const [winner, setWinner] = useState<Song | null>(() =>
-    round.status === "CLOSED" ? (round.candidates[0] ?? null) : null
-  );
+  const [showWinner, setShowWinner] = useState(round.status === "CLOSED");
 
   // Keep live vote bars in sync with incoming updates from the hook.
   useEffect(() => {
     setCandidates(round.candidates);
   }, [round.candidates]);
 
-  // Trigger winner screen once when the round closes, with proper cleanup.
+  // Show winner screen when round closes.
   useEffect(() => {
     if (round.status !== "CLOSED") return;
-    setWinner(round.candidates[0] ?? null);
+    setShowWinner(true);
     const id = setTimeout(() => onRoundClosed(), WINNER_DISPLAY_MS);
     return () => clearTimeout(id);
-  }, [round.status, round.id, onRoundClosed, round.candidates]);
+  }, [round.status, round.id, onRoundClosed]);
 
   // Countdown timer
   useEffect(() => {
@@ -79,7 +80,7 @@ export default function VotingPhase({
         setHasVoted(true);
         setVotedSongId(song.id);
       } else if (status === 410) {
-        setWinner(candidates[0] ?? null);
+        setShowWinner(true);
         setTimeout(() => onRoundClosed(), WINNER_DISPLAY_MS);
       } else {
         setError("Could not cast vote. Please try again.");
@@ -92,9 +93,10 @@ export default function VotingPhase({
   const maxVotes = Math.max(...candidates.map((s) => s.currentVoteCount ?? 0), 1);
   const timerPercent = secondsLeft !== null && totalSeconds ? (secondsLeft / totalSeconds) * 100 : 0;
   const timerColor = secondsLeft !== null && secondsLeft <= 10 ? "#FF2D7E" : "#00C2FF";
+  const sortedCandidates = [...candidates].sort((a, b) => (b.currentVoteCount ?? 0) - (a.currentVoteCount ?? 0));
 
   // Winner screen
-  if (winner) {
+  if (showWinner) {
     return (
       <div
         style={{
@@ -116,43 +118,45 @@ export default function VotingPhase({
           Next up...
         </Title>
 
-        <div
-          style={{
-            background: "linear-gradient(135deg, #FF2D7E 0%, #C91F5E 100%)",
-            borderRadius: 16,
-            padding: 32,
-            textAlign: "center",
-            maxWidth: 400,
-            width: "100%",
-            boxShadow: "0 0 60px rgba(255, 45, 126, 0.4)",
-          }}
-        >
-          {winner.albumArt && (
-            <Image
-              src={winner.albumArt}
-              alt="album art"
-              width={120}
-              height={120}
-              style={{ borderRadius: 8, marginBottom: 16 }}
-            />
-          )}
-          <Title level={2} style={{ color: "#FFFFFF", margin: 0 }}>
-            {winner.title}
-          </Title>
-          <Text style={{ color: "rgba(255,255,255,0.8)", fontSize: 16 }}>
-            {winner.artist}
-          </Text>
-          {winner.addedBy && (
-            <Text style={{ color: "rgba(255,255,255,0.7)", fontSize: 15, display: "block", marginTop: 12 }}>
-              🎤 {winner.addedBy.username}
+        {currentSong && (
+          <div
+            style={{
+              background: "linear-gradient(135deg, #FF2D7E 0%, #C91F5E 100%)",
+              borderRadius: 16,
+              padding: 32,
+              textAlign: "center",
+              maxWidth: 400,
+              width: "100%",
+              boxShadow: "0 0 60px rgba(255, 45, 126, 0.4)",
+            }}
+          >
+            {currentSong.albumArt && (
+              <Image
+                src={currentSong.albumArt}
+                alt="album art"
+                width={120}
+                height={120}
+                style={{ borderRadius: 8, marginBottom: 16 }}
+              />
+            )}
+            <Title level={2} style={{ color: "#FFFFFF", margin: 0 }}>
+              {currentSong.title}
+            </Title>
+            <Text style={{ color: "rgba(255,255,255,0.8)", fontSize: 16 }}>
+              {currentSong.artist}
             </Text>
-          )}
-          <div style={{ marginTop: 8 }}>
-            <Text style={{ color: "rgba(255,255,255,0.6)", fontSize: 14 }}>
-              {winner.currentVoteCount ?? 0} votes
-            </Text>
+            {currentSong.addedBy && (
+              <Text style={{ color: "rgba(255,255,255,0.7)", fontSize: 15, display: "block", marginTop: 12 }}>
+                🎤 {currentSong.addedBy.username}
+              </Text>
+            )}
+            <div style={{ marginTop: 8 }}>
+              <Text style={{ color: "rgba(255,255,255,0.6)", fontSize: 14 }}>
+                {currentSong.currentVoteCount ?? 0} votes
+              </Text>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }
@@ -199,63 +203,96 @@ export default function VotingPhase({
           )}
         </div>
 
-        {/* Song Cards */}
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
-            gap: 16,
-          }}
-        >
-          {candidates.map((song) => {
-            const isVoted = votedSongId === song.id;
-            const votePercentage = ((song.currentVoteCount ?? 0) / maxVotes) * 100;
+        {/* Content: Song Cards + Leaderboard */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 300px", gap: 24 }}>
 
-            return (
-              <div
-                key={song.id}
-                style={{
-                  background: isVoted
-                    ? "linear-gradient(135deg, #FF2D7E 0%, #C91F5E 100%)"
-                    : "#1A1A2E",
-                  border: isVoted ? "2px solid #FF2D7E" : "1px solid rgba(255,255,255,0.1)",
-                  borderRadius: 8,
-                  padding: 16,
-                }}
-              >
-                <div style={{ marginBottom: 16 }}>
-                  <Text strong style={{ color: "#FFFFFF", fontSize: 16, display: "block", marginBottom: 4 }}>
-                    {song.title}
-                  </Text>
-                  <Text style={{ color: "rgba(255,255,255,0.65)" }}>{song.artist}</Text>
-                  {song.addedBy && (
-                    <Text style={{ color: "rgba(255,255,255,0.35)", fontSize: 12 }}>🎤 {song.addedBy.username}</Text>
-                  )}
+          {/* Song Cards */}
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 16, alignContent: "start" }}>
+            {candidates.map((song) => {
+              const isVoted = votedSongId === song.id;
+              const votePercentage = ((song.currentVoteCount ?? 0) / maxVotes) * 100;
+
+              return (
+                <div
+                  key={song.id}
+                  style={{
+                    background: isVoted
+                      ? "linear-gradient(135deg, #FF2D7E 0%, #C91F5E 100%)"
+                      : "#1A1A2E",
+                    border: isVoted ? "2px solid #FF2D7E" : "1px solid rgba(255,255,255,0.1)",
+                    borderRadius: 8,
+                    padding: 16,
+                  }}
+                >
+                  <div style={{ marginBottom: 16 }}>
+                    <Text strong style={{ color: "#FFFFFF", fontSize: 16, display: "block", marginBottom: 4 }}>
+                      {song.title}
+                    </Text>
+                    <Text style={{ color: "rgba(255,255,255,0.65)" }}>{song.artist}</Text>
+                    {song.addedBy && (
+                      <Text style={{ color: "rgba(255,255,255,0.35)", fontSize: 12 }}>🎤 {song.addedBy.username}</Text>
+                    )}
+                  </div>
+
+                  <Progress
+                    percent={votePercentage}
+                    showInfo={false}
+                    strokeColor="#00C2FF"
+                    railColor="rgba(255,255,255,0.1)"
+                    style={{ marginBottom: 12 }}
+                  />
+
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <Text style={{ color: "#FFFFFF" }}>{song.currentVoteCount ?? 0} votes</Text>
+                    {isVoted && (
+                      <span style={{ color: "#FFFFFF", fontWeight: 600, fontSize: 14 }}>✓ Voted</span>
+                    )}
+                    {!hasVoted && (
+                      <Button type="primary" loading={voting} onClick={() => handleVote(song)}>
+                        Vote
+                      </Button>
+                    )}
+                  </div>
                 </div>
+              );
+            })}
+          </div>
 
-                <Progress
-                  percent={votePercentage}
-                  showInfo={false}
-                  strokeColor="#00C2FF"
-                  railColor="rgba(255,255,255,0.1)"
-                  style={{ marginBottom: 12 }}
-                />
-
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                  <Text style={{ color: "#FFFFFF" }}>{song.currentVoteCount ?? 0} votes</Text>
-                  <Button
-                    type={isVoted ? "default" : "primary"}
-                    disabled={hasVoted || voting}
-                    onClick={() => handleVote(song)}
-                  >
-                    {isVoted ? "Voted" : "Vote"}
-                  </Button>
+          {/* Live Leaderboard */}
+          <Card
+            title={
+              <span style={{ color: "#FFFFFF", fontSize: 18 }}>
+                <TrophyOutlined style={{ marginRight: 8, color: "#FFD700" }} />
+                Live Leaderboard
+              </span>
+            }
+            style={{ height: "fit-content", position: "sticky", top: 24, background: "#1A1A2E", border: "1px solid rgba(255,255,255,0.08)" }}
+            styles={{ header: { background: "#1A1A2E", borderBottom: "1px solid rgba(255,255,255,0.08)" } }}
+          >
+            <div>
+              {sortedCandidates.map((song, index) => (
+                <div key={song.id} style={{ borderBottom: index < sortedCandidates.length - 1 ? "1px solid rgba(255,255,255,0.08)" : "none", padding: "12px 0", display: "flex", alignItems: "center", gap: 12 }}>
+                  <div style={{
+                    width: 32, height: 32, borderRadius: "50%", flexShrink: 0,
+                    background: index === 0 ? "#FFD700" : index === 1 ? "#C0C0C0" : index === 2 ? "#CD7F32" : "#2A2A3E",
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                    fontWeight: "bold", color: index < 3 ? "#000000" : "#FFFFFF", fontSize: 14,
+                  }}>
+                    {index + 1}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <Text strong style={{ color: "#FFFFFF", display: "block", fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {song.title}
+                    </Text>
+                    <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 12 }}>{song.artist}</Text>
+                  </div>
+                  <Badge count={song.currentVoteCount ?? 0} showZero style={{ backgroundColor: index === 0 ? "#FF2D7E" : "rgba(255,255,255,0.15)", flexShrink: 0 }} />
                 </div>
-              </div>
-            );
-          })}
+              ))}
+            </div>
+          </Card>
+
         </div>
-
       </div>
     </div>
   );

--- a/app/components/VotingPhase.tsx
+++ b/app/components/VotingPhase.tsx
@@ -194,11 +194,6 @@ export default function VotingPhase({
             </div>
           )}
 
-          {hasVoted && (
-            <Text style={{ color: "rgba(255,255,255,0.45)", display: "block", marginTop: 12 }}>
-              Your vote has been cast!
-            </Text>
-          )}
           {error && (
             <Alert type="error" title={error} showIcon closable style={{ marginTop: 16, maxWidth: 560, margin: "16px auto 0" }} />
           )}

--- a/app/components/WaitingLobby.tsx
+++ b/app/components/WaitingLobby.tsx
@@ -76,7 +76,7 @@ export default function WaitingLobby({ sessionName, gamePin, participants, isAdm
 
         <div style={{ background: "rgba(255, 255, 255, 0.03)", border: "1px solid rgba(255, 255, 255, 0.08)", borderRadius: 12, padding: "16px 24px", width: "100%", maxWidth: 400 }}>
           <Text style={{ color: "rgba(255,255,255,0.6)", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", display: "block", marginBottom: 12 }}>
-            Teilnehmer{" "}
+            Participants{" "}
             <Badge count={participants.length} style={{ backgroundColor: "#FF2D7E" }} />
           </Text>
           {participants.length === 0 ? (

--- a/app/components/WaitingLobby.tsx
+++ b/app/components/WaitingLobby.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { Button, Typography, Badge, Alert, Avatar } from "antd";
+import { ArrowLeftOutlined, UserOutlined } from "@ant-design/icons";
+import { Participant } from "@/types/session";
+
+const { Text, Title } = Typography;
+
+interface WaitingLobbyProps {
+  sessionName: string;
+  gamePin: string;
+  participants: Participant[];
+  isAdmin: boolean;
+  error: string;
+  startingSession: boolean;
+  onStart: () => void;
+  onBack: () => void;
+}
+
+export default function WaitingLobby({ sessionName, gamePin, participants, isAdmin, error, startingSession, onStart, onBack }: WaitingLobbyProps) {
+  return (
+    <div style={{ minHeight: "100vh", background: "#0D0D1A", display: "flex", flexDirection: "column" }}>
+      <div
+        style={{
+          background: "rgba(13, 13, 26, 0.97)",
+          borderBottom: "1px solid rgba(255, 45, 126, 0.20)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0 24px",
+          height: 56,
+        }}
+      >
+        <Button
+          type="text"
+          icon={<ArrowLeftOutlined />}
+          onClick={onBack}
+          style={{ color: "#FFFFFF" }}
+        >
+          Back to Dashboard
+        </Button>
+        {gamePin && (
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 12 }}>PIN</Text>
+            <Text style={{ color: "#FF2D7E", fontWeight: 700, fontSize: 20, letterSpacing: "0.18em" }}>
+              {gamePin}
+            </Text>
+          </div>
+        )}
+        <div style={{ width: 160 }} />
+      </div>
+
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "40px 24px", gap: 40 }}>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: 48, marginBottom: 12, filter: "drop-shadow(0 0 20px rgba(255, 45, 126, 0.5))" }}>
+            🎤
+          </div>
+          <Title level={2} style={{ color: "#FFFFFF", margin: 0, fontSize: 28, fontWeight: 700 }}>
+            {sessionName || "Karaoke Session"}
+          </Title>
+          <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 15, display: "block", marginTop: 8 }}>
+            {isAdmin ? "Everyone ready? Let's get this party started!" : "Waiting for the party to begin..."}
+          </Text>
+        </div>
+
+        {gamePin && (
+          <div style={{ background: "rgba(255, 45, 126, 0.08)", border: "1px solid rgba(255, 45, 126, 0.30)", borderRadius: 12, padding: "16px 40px", textAlign: "center" }}>
+            <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 11, letterSpacing: "0.12em", textTransform: "uppercase", display: "block", marginBottom: 4 }}>
+              Join with PIN
+            </Text>
+            <Text style={{ color: "#FF2D7E", fontSize: 34, fontWeight: 800, letterSpacing: "0.22em" }}>
+              {gamePin}
+            </Text>
+          </div>
+        )}
+
+        <div style={{ background: "rgba(255, 255, 255, 0.03)", border: "1px solid rgba(255, 255, 255, 0.08)", borderRadius: 12, padding: "16px 24px", width: "100%", maxWidth: 400 }}>
+          <Text style={{ color: "rgba(255,255,255,0.6)", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", display: "block", marginBottom: 12 }}>
+            Teilnehmer{" "}
+            <Badge count={participants.length} style={{ backgroundColor: "#FF2D7E" }} />
+          </Text>
+          {participants.length === 0 ? (
+            <Text style={{ color: "rgba(255,255,255,0.25)", fontSize: 13 }}>No participants yet...</Text>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {participants.map((p) => (
+                <div key={p.id} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <Avatar size={30} icon={<UserOutlined />} style={{ background: "rgba(255, 45, 126, 0.3)", flexShrink: 0 }} />
+                  <Text style={{ color: "#FFFFFF", fontSize: 14 }}>{p.username}</Text>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <Alert type="error" description={error} closable style={{ maxWidth: 400, width: "100%" }} />
+        )}
+
+        {isAdmin && (
+          <Button type="primary" size="large" loading={startingSession} onClick={onStart} style={{ height: 56, fontSize: 18, fontWeight: 600 }}>
+            🎉 Start the Party
+          </Button>
+        )}
+
+        {!isAdmin && (
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  style={{
+                    width: 8, height: 8, borderRadius: "50%", background: "#FF2D7E",
+                    animation: `pulse 1.4s ease-in-out ${i * 0.2}s infinite`, opacity: 0.7,
+                  }}
+                />
+              ))}
+              <style>{`
+                @keyframes pulse {
+                  0%, 100% { transform: scale(1); opacity: 0.4; }
+                  50% { transform: scale(1.4); opacity: 1; }
+                }
+              `}</style>
+            </div>
+            <Text style={{ color: "rgba(255,255,255,0.4)", fontSize: 13 }}>
+              Waiting for the Admin to start the Party...
+            </Text>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/YouTubePlayer.tsx
+++ b/app/components/YouTubePlayer.tsx
@@ -128,10 +128,10 @@ export default function YouTubePlayer({ currentSong, isAdmin, isActive, isPaused
     if (!playerReadyRef.current || !playerRef.current) return;
     if (isPaused) {
       playerRef.current.pauseVideo();
-    } else if (isActive) {
+    } else if (isActive && currentSong) {
       playerRef.current.playVideo();
     }
-  }, [isPaused, isActive]);
+  }, [isPaused, isActive, currentSong]);
 
   // Destroy player on unmount
   useEffect(() => {

--- a/app/components/YouTubePlayer.tsx
+++ b/app/components/YouTubePlayer.tsx
@@ -26,6 +26,8 @@ export default function YouTubePlayer({ currentSong, isAdmin, isActive, isPaused
   const currentSongIdRef = useRef<number | null>(null);
   const onTrackEndRef = useRef(onTrackEnd);
   onTrackEndRef.current = onTrackEnd;
+  const isPausedRef = useRef(isPaused);
+  isPausedRef.current = isPaused;
 
   const [ytReady, setYtReady] = useState(false);
 
@@ -60,7 +62,11 @@ export default function YouTubePlayer({ currentSong, isAdmin, isActive, isPaused
         onReady: () => {
           playerReadyRef.current = true;
           if (pendingVideoIdRef.current) {
-            playerRef.current?.loadVideoById(pendingVideoIdRef.current);
+            if (isPausedRef.current) {
+              playerRef.current?.cueVideoById(pendingVideoIdRef.current);
+            } else {
+              playerRef.current?.loadVideoById(pendingVideoIdRef.current);
+            }
             pendingVideoIdRef.current = null;
           }
         },
@@ -75,7 +81,16 @@ export default function YouTubePlayer({ currentSong, isAdmin, isActive, isPaused
 
   // Search YouTube and play when song changes
   useEffect(() => {
-    if (!isAdmin || !isActive || !ytReady || !currentSong) return;
+    if (!isAdmin || !isActive || !ytReady) return;
+
+    if (!currentSong) {
+      if (playerReadyRef.current && playerRef.current) {
+        playerRef.current.stopVideo();
+        currentSongIdRef.current = null;
+      }
+      return;
+    }
+
     if (currentSong.id === currentSongIdRef.current) return;
     currentSongIdRef.current = currentSong.id;
 
@@ -92,7 +107,11 @@ export default function YouTubePlayer({ currentSong, isAdmin, isActive, isPaused
         if (!videoId) return;
 
         if (playerReadyRef.current && playerRef.current) {
-          playerRef.current.loadVideoById(videoId);
+          if (isPausedRef.current) {
+            playerRef.current.cueVideoById(videoId);
+          } else {
+            playerRef.current.loadVideoById(videoId);
+          }
         } else {
           pendingVideoIdRef.current = videoId;
         }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,8 +13,9 @@ const { Title, Text } = Typography;
 
 const ACTIVE_STATUSES: SessionStatus[] = ["CREATED", "ACTIVE", "PAUSED"];
 
-function SessionCard({ session, onRejoin }: { session: Session; onRejoin: (id: string) => void }) {
+function SessionCard({ session, onRejoin, onViewReview }: { session: Session; onRejoin: (id: string) => void; onViewReview: (id: string) => void }) {
   const isActive = session.status && ACTIVE_STATUSES.includes(session.status);
+  const isEnded = session.status === "ENDED";
   const createdAt = session.createdAt ? new Date(session.createdAt).toLocaleDateString() : "—";
 
   return (
@@ -47,6 +48,11 @@ function SessionCard({ session, onRejoin }: { session: Session; onRejoin: (id: s
           {isActive && (
             <Button type="link" onClick={() => onRejoin(session.id)} style={{ padding: 0 }}>
               Rejoin
+            </Button>
+          )}
+          {isEnded && (
+            <Button type="link" onClick={() => onViewReview(session.id)} style={{ padding: 0, color: "#FF2D7E" }}>
+              View Results
             </Button>
           )}
         </div>
@@ -90,6 +96,10 @@ export default function Dashboard() {
     router.push(`/sessions/${sessionId}`);
   };
 
+  const handleViewReview = (sessionId: string) => {
+    router.push(`/sessions/${sessionId}/review`);
+  };
+
   const createdSessions = sessions.filter((s) => s.admin && String(s.admin.id) === String(userId));
   const joinedSessions  = sessions.filter((s) => !s.admin || String(s.admin.id) !== String(userId));
 
@@ -117,7 +127,7 @@ export default function Dashboard() {
         <div style={{ marginTop: 16 }}>
           {createdSessions.length === 0
             ? <Text style={{ color: "rgba(255,255,255,0.3)" }}>No created sessions yet</Text>
-            : createdSessions.map((s) => <SessionCard key={s.id} session={s} onRejoin={handleRejoin} />)
+            : createdSessions.map((s) => <SessionCard key={s.id} session={s} onRejoin={handleRejoin} onViewReview={handleViewReview} />)
           }
         </div>
       ),
@@ -129,7 +139,7 @@ export default function Dashboard() {
         <div style={{ marginTop: 16 }}>
           {joinedSessions.length === 0
             ? <Text style={{ color: "rgba(255,255,255,0.3)" }}>No joined sessions yet</Text>
-            : joinedSessions.map((s) => <SessionCard key={s.id} session={s} onRejoin={handleRejoin} />)
+            : joinedSessions.map((s) => <SessionCard key={s.id} session={s} onRejoin={handleRejoin} onViewReview={handleViewReview} />)
           }
         </div>
       ),

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -84,10 +84,6 @@ export default function Dashboard() {
     clearToken();
     clearUserId();
     clearUsername();
-    localStorage.removeItem("spotify_access_token");
-    localStorage.removeItem("spotify_refresh_token");
-    localStorage.removeItem("spotify_token_expiry");
-    localStorage.removeItem("spotify_device_id");
     router.push("/");
   };
 

--- a/app/hooks/useSessionStatus.ts
+++ b/app/hooks/useSessionStatus.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useApi } from "@/hooks/useApi";
 import { useStomp } from "@/context/StompContext";
 import { Session, SessionStatus } from "@/types/session";
@@ -12,8 +12,6 @@ export interface UseSessionStatusResult {
   isLoading: boolean;
 }
 
-const POLL_INTERVAL_MS = 3000;
-
 export const useSessionStatus = (sessionId: string, userId: string): UseSessionStatusResult => {
   const apiService = useApi();
   const { client, connected } = useStomp();
@@ -25,11 +23,8 @@ export const useSessionStatus = (sessionId: string, userId: string): UseSessionS
   const [participants, setParticipants] = useState<{ id: number; username: string }[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const statusRef = useRef<SessionStatus | null>(null);
-
   const applySession = useCallback((session: Session, currentUserId: string) => {
     const newStatus = session.status ?? null;
-    statusRef.current = newStatus;
     setStatus(newStatus);
     setIsAdmin(String(session.admin?.id) === String(currentUserId));
     setGamePin(session.gamePin ?? "");
@@ -67,7 +62,6 @@ export const useSessionStatus = (sessionId: string, userId: string): UseSessionS
           const newStatus: SessionStatus =
             typeof data === "string" ? data : data.status;
           if (newStatus) {
-            statusRef.current = newStatus;
             setStatus(newStatus);
           }
           // If we got a full session, also update participants
@@ -97,20 +91,6 @@ export const useSessionStatus = (sessionId: string, userId: string): UseSessionS
       participantsSub.unsubscribe();
     };
   }, [sessionId, client, connected]);
-
-  // Polling fallback while session is in CREATED state
-  // (in case the WebSocket publisher is not yet implemented server-side)
-  useEffect(() => {
-    if (!sessionId) return;
-
-    const interval = setInterval(() => {
-      if (statusRef.current === "CREATED") {
-        fetchSession();
-      }
-    }, POLL_INTERVAL_MS);
-
-    return () => clearInterval(interval);
-  }, [sessionId, fetchSession]);
 
   return { status, isAdmin, gamePin, sessionName, participants, isLoading };
 };

--- a/app/hooks/useSessionStatus.ts
+++ b/app/hooks/useSessionStatus.ts
@@ -33,7 +33,7 @@ export const useSessionStatus = (sessionId: string, userId: string): UseSessionS
   }, []);
 
   const fetchSession = useCallback(async () => {
-    if (!sessionId) return;
+    if (!sessionId || !userId) return;
     try {
       const session = await apiService.get<Session>(`/sessions/${sessionId}`);
       applySession(session, userId);

--- a/app/hooks/useSessionStatus.ts
+++ b/app/hooks/useSessionStatus.ts
@@ -1,14 +1,14 @@
 import { useState, useEffect, useCallback } from "react";
 import { useApi } from "@/hooks/useApi";
 import { useStomp } from "@/context/StompContext";
-import { Session, SessionStatus } from "@/types/session";
+import { Session, SessionStatus, Participant } from "@/types/session";
 
 export interface UseSessionStatusResult {
   status: SessionStatus | null;
   isAdmin: boolean;
   gamePin: string;
   sessionName: string;
-  participants: { id: number; username: string }[];
+  participants: Participant[];
   isLoading: boolean;
 }
 
@@ -20,7 +20,7 @@ export const useSessionStatus = (sessionId: string, userId: string): UseSessionS
   const [isAdmin, setIsAdmin] = useState(false);
   const [gamePin, setGamePin] = useState("");
   const [sessionName, setSessionName] = useState("");
-  const [participants, setParticipants] = useState<{ id: number; username: string }[]>([]);
+  const [participants, setParticipants] = useState<Participant[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   const applySession = useCallback((session: Session, currentUserId: string) => {

--- a/app/hooks/useSongSearch.ts
+++ b/app/hooks/useSongSearch.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useApi } from "@/hooks/useApi";
+import { SongSearchResult } from "@/types/song";
+import { App } from "antd";
+
+export function useSongSearch(sessionId: string, onSuccess: () => void) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SongSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const { notification } = App.useApp();
+  const apiService = useApi();
+
+  useEffect(() => {
+    const query = searchQuery.trim();
+    if (!query) {
+      setSearchResults([]);
+      return;
+    }
+
+    const timeout = setTimeout(async () => {
+      setIsLoading(true);
+      try {
+        const params = new URLSearchParams({ query });
+        const data = await apiService.get<SongSearchResult[]>(`/songs/search?${params}`);
+        setSearchResults(data);
+      } catch {
+        notification.error({
+          title: "Search failed",
+          description: "Could not reach the server.",
+        });
+        setSearchResults([]);
+      } finally {
+        setIsLoading(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timeout);
+  }, [searchQuery, notification, apiService]);
+
+  const handleAddSong = async (song: SongSearchResult) => {
+    try {
+      await apiService.post(`/sessions/${sessionId}/songs`, {
+        spotifyId: song.spotifyId,
+        title: song.title,
+        artist: song.artist,
+        durationMs: song.durationMs,
+      });
+      notification.success({
+        title: "Song Added",
+        description: `"${song.title}" by ${song.artist} has been added to the queue.`,
+        placement: "bottomRight",
+      });
+      setSearchQuery("");
+      setSearchResults([]);
+      onSuccess();
+    } catch {
+      notification.error({
+        title: "Failed to add song",
+        description: "Could not add the song to the queue.",
+      });
+    }
+  };
+
+  return { searchQuery, setSearchQuery, searchResults, isLoading, handleAddSong };
+}

--- a/app/join-session/page.tsx
+++ b/app/join-session/page.tsx
@@ -16,13 +16,12 @@ export default function JoinSession() {
   const router = useRouter();
   const apiService = useApi();
 
-  const { set: setSessionId } = useLocalStorage<string>("sessionId", "");
+  const { set: setSessionId, value: currentSessionId } = useLocalStorage<string>("sessionId", "");
 
   const [pin, setPin] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [step, setStep] = useState<"pin" | "song-selection">("pin");
-  const [currentSessionId, setCurrentSessionId] = useState("");
 
   const handleJoinWithPin = async () => {
     setError("");
@@ -39,7 +38,6 @@ export default function JoinSession() {
         { gamePin: pin }
       );
       setSessionId(session.id);
-      setCurrentSessionId(session.id);
 
       if (joined.requiresSongSelection) {
         setStep("song-selection");

--- a/app/join-session/page.tsx
+++ b/app/join-session/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import useLocalStorage from "@/hooks/useLocalStorage";
 import { Session } from "@/types/session";
-import { Card, Typography, Layout, Button, Input, Alert } from "antd";
+import { Card, Typography, Layout, Button, Input, Alert, Steps } from "antd";
 import { ArrowLeftOutlined } from "@ant-design/icons";
 import SongSearchContent from "@/components/SongSearchContent";
 
@@ -83,6 +83,16 @@ export default function JoinSession() {
 
       <Content style={{ padding: "48px 24px" }}>
         <div style={{ maxWidth: 600, margin: "0 auto" }}>
+          <Card style={{ marginBottom: 32 }}>
+            <Steps
+              current={step === "pin" ? 0 : 1}
+              items={[
+                { title: "Enter PIN" },
+                { title: "Add a Song" },
+              ]}
+            />
+          </Card>
+
           {step === "pin" && (
             <Card>
               <div style={{ textAlign: "center", padding: "48px 24px" }}>

--- a/app/sessions/[sessionId]/page.tsx
+++ b/app/sessions/[sessionId]/page.tsx
@@ -67,6 +67,18 @@ export default function SessionPage() {
   const displayQueue = queue.filter((s: Song) => s.id !== currentSong?.id);
   const { openRound, clearRound } = useVotingRound(sessionId);
 
+const handleBackToDashboard = async () => {
+    if (isAdmin && status === "ACTIVE") {
+      try {
+        await apiService.put(`/sessions/${sessionId}`, { status: "PAUSED" });
+      } catch {
+        // navigate anyway even if pause fails
+      }
+    }
+    clearSessionId();
+    router.push("/dashboard");
+  };
+
 const handleStartSession = async () => {
     setError("");
     setStartingSession(true);
@@ -117,7 +129,7 @@ const handleStartSession = async () => {
           <Button
             type="text"
             icon={<ArrowLeftOutlined />}
-            onClick={() => { clearSessionId(); router.push("/dashboard"); }}
+            onClick={handleBackToDashboard}
             style={{ color: "#FFFFFF" }}
           >
             Back to Dashboard
@@ -238,22 +250,34 @@ const handleStartSession = async () => {
           <Button
             type="text"
             icon={<ArrowLeftOutlined />}
-            onClick={() => { clearSessionId(); router.push("/dashboard"); }}
+            onClick={handleBackToDashboard}
             style={{ color: "#FFFFFF" }}
           >
             Back to Dashboard
           </Button>
         </div>
 
-        {/* Center: PIN */}
-        {gamePin && (
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 12 }}>PIN</Text>
-            <Text style={{ color: "#FF2D7E", fontWeight: 700, fontSize: 20, letterSpacing: "0.18em" }}>
-              {gamePin}
-            </Text>
-          </div>
-        )}
+        {/* Center: PIN + Status */}
+        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+          {gamePin && (
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 12 }}>PIN</Text>
+              <Text style={{ color: "#FF2D7E", fontWeight: 700, fontSize: 20, letterSpacing: "0.18em" }}>
+                {gamePin}
+              </Text>
+            </div>
+          )}
+          {(status === "ACTIVE" || status === "PAUSED") && (
+            <Badge
+              status={status === "ACTIVE" ? "processing" : "warning"}
+              text={
+                <Text style={{ color: status === "ACTIVE" ? "#1DB954" : "#faad14", fontSize: 12 }}>
+                  {status === "ACTIVE" ? "Active" : "Paused"}
+                </Text>
+              }
+            />
+          )}
+        </div>
 
         {/* Right: controls */}
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
@@ -273,7 +297,7 @@ const handleStartSession = async () => {
                 onConfirm={handleEndSession}
                 okText="Yes"
                 cancelText="No"
-                overlayInnerStyle={{ backgroundColor: "#1A1A2E", color: "#FF2D7E", border: "1px solid rgba(255,45,126,0.3)", borderRadius: 8 }}
+                styles={{ root: { backgroundColor: "#1A1A2E", border: "1px solid rgba(255,45,126,0.3)", borderRadius: 8 }, container: { backgroundColor: "#1A1A2E", borderRadius: 8 } }}
               >
                 <Tooltip title="End Session">
                   <Button type="text" danger icon={<PoweroffOutlined />} style={{ fontSize: 20 }} />

--- a/app/sessions/[sessionId]/page.tsx
+++ b/app/sessions/[sessionId]/page.tsx
@@ -15,12 +15,13 @@ import ReactionBar from "../../components/ReactionBar";
 import { Song } from "@/types/song";
 import { ApplicationError } from "@/types/error";
 import YouTubePlayer from "../../components/YouTubePlayer";
-import Image from "next/image";
-import { Layout, Button, Typography, Tooltip, Badge, Alert, Spin, Avatar, Space, Popconfirm } from "antd";
-import { ArrowLeftOutlined, DeleteOutlined, PlusOutlined, UserOutlined, PauseCircleOutlined, PlayCircleOutlined, PoweroffOutlined } from "@ant-design/icons";
+import WaitingLobby from "../../components/WaitingLobby";
+import SessionSidebar from "../../components/SessionSidebar";
+import { Layout, Button, Typography, Tooltip, Badge, Alert, Spin, Space, Popconfirm } from "antd";
+import { ArrowLeftOutlined, PauseCircleOutlined, PlayCircleOutlined, PoweroffOutlined } from "@ant-design/icons";
 
 const { Header, Content } = Layout;
-const { Text, Title } = Typography;
+const { Text } = Typography;
 
 export default function SessionPage() {
   const router = useRouter();
@@ -114,116 +115,16 @@ const handleStartSession = async () => {
   // ── Waiting Lobby (status === "CREATED") ─────────────────────────────────────
   if (status === "CREATED") {
     return (
-      <div style={{ minHeight: "100vh", background: "#0D0D1A", display: "flex", flexDirection: "column" }}>
-        <div
-          style={{
-            background: "rgba(13, 13, 26, 0.97)",
-            borderBottom: "1px solid rgba(255, 45, 126, 0.20)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            padding: "0 24px",
-            height: 56,
-          }}
-        >
-          <Button
-            type="text"
-            icon={<ArrowLeftOutlined />}
-            onClick={handleBackToDashboard}
-            style={{ color: "#FFFFFF" }}
-          >
-            Back to Dashboard
-          </Button>
-          {gamePin && (
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 12 }}>PIN</Text>
-              <Text style={{ color: "#FF2D7E", fontWeight: 700, fontSize: 20, letterSpacing: "0.18em" }}>
-                {gamePin}
-              </Text>
-            </div>
-          )}
-          <div style={{ width: 160 }} />
-        </div>
-
-        <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "40px 24px", gap: 40 }}>
-          <div style={{ textAlign: "center" }}>
-            <div style={{ fontSize: 48, marginBottom: 12, filter: "drop-shadow(0 0 20px rgba(255, 45, 126, 0.5))" }}>
-              🎤
-            </div>
-            <Title level={2} style={{ color: "#FFFFFF", margin: 0, fontSize: 28, fontWeight: 700 }}>
-              {sessionName || "Karaoke Session"}
-            </Title>
-            <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 15, display: "block", marginTop: 8 }}>
-              {isAdmin ? "Everyone ready? Let's get this party started!" : "Waiting for the party to begin..."}
-            </Text>
-          </div>
-
-          {gamePin && (
-            <div style={{ background: "rgba(255, 45, 126, 0.08)", border: "1px solid rgba(255, 45, 126, 0.30)", borderRadius: 12, padding: "16px 40px", textAlign: "center" }}>
-              <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 11, letterSpacing: "0.12em", textTransform: "uppercase", display: "block", marginBottom: 4 }}>
-                Join with PIN
-              </Text>
-              <Text style={{ color: "#FF2D7E", fontSize: 34, fontWeight: 800, letterSpacing: "0.22em" }}>
-                {gamePin}
-              </Text>
-            </div>
-          )}
-
-          <div style={{ background: "rgba(255, 255, 255, 0.03)", border: "1px solid rgba(255, 255, 255, 0.08)", borderRadius: 12, padding: "16px 24px", width: "100%", maxWidth: 400 }}>
-            <Text style={{ color: "rgba(255,255,255,0.6)", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", display: "block", marginBottom: 12 }}>
-              Teilnehmer{" "}
-              <Badge count={participants.length} style={{ backgroundColor: "#FF2D7E" }} />
-            </Text>
-            {participants.length === 0 ? (
-              <Text style={{ color: "rgba(255,255,255,0.25)", fontSize: 13 }}>No participants yet...</Text>
-            ) : (
-              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                {participants.map((p) => (
-                  <div key={p.id} style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                    <Avatar size={30} icon={<UserOutlined />} style={{ background: "rgba(255, 45, 126, 0.3)", flexShrink: 0 }} />
-                    <Text style={{ color: "#FFFFFF", fontSize: 14 }}>{p.username}</Text>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {error && (
-            <Alert type="error" description={error} closable style={{ maxWidth: 400, width: "100%" }} />
-          )}
-
-          {isAdmin && (
-            <Button type="primary" size="large" loading={startingSession} onClick={handleStartSession} style={{ height: 56, fontSize: 18, fontWeight: 600 }}>
-              🎉 Start the Party
-            </Button>
-          )}
-
-          {!isAdmin && (
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                {[0, 1, 2].map((i) => (
-                  <div
-                    key={i}
-                    style={{
-                      width: 8, height: 8, borderRadius: "50%", background: "#FF2D7E",
-                      animation: `pulse 1.4s ease-in-out ${i * 0.2}s infinite`, opacity: 0.7,
-                    }}
-                  />
-                ))}
-                <style>{`
-                  @keyframes pulse {
-                    0%, 100% { transform: scale(1); opacity: 0.4; }
-                    50% { transform: scale(1.4); opacity: 1; }
-                  }
-                `}</style>
-              </div>
-              <Text style={{ color: "rgba(255,255,255,0.4)", fontSize: 13 }}>
-                Waiting for the Admin to start the Party...
-              </Text>
-            </div>
-          )}
-        </div>
-      </div>
+      <WaitingLobby
+        sessionName={sessionName}
+        gamePin={gamePin}
+        participants={participants}
+        isAdmin={isAdmin}
+        error={error}
+        startingSession={startingSession}
+        onStart={handleStartSession}
+        onBack={handleBackToDashboard}
+      />
     );
   }
 
@@ -288,6 +189,7 @@ const handleStartSession = async () => {
                   type="text"
                   icon={status === "PAUSED" ? <PlayCircleOutlined /> : <PauseCircleOutlined />}
                   onClick={handlePauseResume}
+                  className="session-control-btn"
                   style={{ color: "#FFFFFF", fontSize: 20 }}
                 />
               </Tooltip>
@@ -320,154 +222,22 @@ const handleStartSession = async () => {
           </div>
         </Content>
 
-        <Layout.Sider
-          width={320}
-          style={{
-            background: "#1A1A2E",
-            borderLeft: "1px solid rgba(255, 255, 255, 0.1)",
+        <SessionSidebar
+          queue={displayQueue}
+          currentSong={currentSong}
+          participants={participants}
+          isAdmin={isAdmin}
+          userId={userId}
+          onAddSong={() => setSearchDrawerOpen(true)}
+          onDeleteSong={(songId) => {
+            setError("");
+            apiService.delete(`/sessions/${sessionId}/songs/${songId}`)
+              .catch((err: ApplicationError) => {
+                setError(err.message ?? "Could not remove song. Please try again.");
+              });
           }}
-        >
-          {/* Wrapper gives the sider a real flex column height */}
-          <div style={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
-
-            {/* ── Queue section (70%) ── */}
-            <div style={{ flex: "7 1 0", minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-              {/* Fixed header */}
-              <div style={{ padding: "24px 24px 0 24px", flexShrink: 0 }}>
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
-                  <Text style={{ color: "#FFFFFF", fontWeight: 600, fontSize: 15 }}>
-                    Party Playlist <Badge count={displayQueue.length} style={{ backgroundColor: "#FF2D7E" }} />
-                  </Text>
-                  <Space size={8}>
-                    {isAdmin && (
-                      <Tooltip title={queue.length === 0 ? "No songs in queue" : "Skip Song"}>
-                        <Button
-                          type="primary"
-                          disabled={queue.length === 0}
-                          size="small"
-                          style={{ background: "#1DB954", borderColor: "#1DB954" }}
-                          onClick={() => apiService.post(`/sessions/${sessionId}/songs/next`, {}).catch(console.error)}
-                        >
-                          Skip
-                        </Button>
-                      </Tooltip>
-                    )}
-                    <Button type="primary" size="small" icon={<PlusOutlined />} onClick={() => setSearchDrawerOpen(true)}>
-                      Add Song
-                    </Button>
-                  </Space>
-                </div>
-              </div>
-
-              {/* Scrollable song list */}
-              <div style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: "0 24px 12px 24px" }}>
-                {currentSong && (
-                  <div style={{ background: "#0D0D1A", borderRadius: 8, border: "1px solid rgba(255, 45, 126, 0.4)", marginBottom: 8, padding: "10px 12px", display: "flex", alignItems: "center", gap: 10 }}>
-                    {currentSong.albumArt && (
-                      <Image src={currentSong.albumArt} alt="album art" width={40} height={40} style={{ borderRadius: 4, flexShrink: 0 }} />
-                    )}
-                    <div>
-                      <div style={{ color: "#FF2D7E", fontSize: 13, fontWeight: 600 }}>{currentSong.title}</div>
-                      <div style={{ color: "rgba(255, 45, 126, 0.6)", fontSize: 12 }}>
-                        {currentSong.artist}{currentSong.addedBy && <span style={{ marginLeft: 6, opacity: 0.7 }}>· 🎤 {currentSong.addedBy.username}</span>}
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {displayQueue.length === 0 ? (
-                  <Text style={{ color: "rgba(255,255,255,0.3)" }}>No songs yet</Text>
-                ) : (
-                  displayQueue.map((song: Song) => (
-                    <div
-                      key={song.id}
-                      style={{ background: "#0D0D1A", borderRadius: 8, border: "1px solid rgba(255,255,255,0.08)", marginBottom: 8, padding: "10px 12px", display: "flex", alignItems: "center", gap: 10 }}
-                    >
-                      {song.albumArt && (
-                        <Image src={song.albumArt} alt="album art" width={40} height={40} style={{ borderRadius: 4, flexShrink: 0 }} />
-                      )}
-                      <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ color: "#FFFFFF", fontSize: 13 }}>{song.title}</div>
-                        <div style={{ color: "rgba(255,255,255,0.5)", fontSize: 12 }}>
-                          {song.artist}{song.addedBy && <span style={{ marginLeft: 6, opacity: 0.7 }}>· 🎤 {song.addedBy.username}</span>}
-                        </div>
-                      </div>
-                      {isAdmin && (
-                        <Tooltip title="Remove song">
-                          <Button
-                            type="text"
-                            size="small"
-                            icon={<DeleteOutlined />}
-                            onClick={() => {
-                              setError("");
-                              apiService.delete(`/sessions/${sessionId}/songs/${song.id}`)
-                                .catch((err: ApplicationError) => {
-                                  setError(err.message ?? "Could not remove song. Please try again.");
-                                });
-                            }}
-                            style={{ color: "rgba(255,80,80,0.7)", flexShrink: 0 }}
-                          />
-                        </Tooltip>
-                      )}
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
-
-            {/* ── Participants section (30%) ── */}
-            <div
-              style={{
-                flex: "3 1 0",
-                minHeight: 0,
-                display: "flex",
-                flexDirection: "column",
-                overflow: "hidden",
-                borderTop: "1px solid rgba(255, 255, 255, 0.1)",
-              }}
-            >
-              {/* Fixed header */}
-              <div style={{ padding: "12px 24px 0 24px", flexShrink: 0 }}>
-                <Text style={{ color: "#FFFFFF", fontWeight: 600, fontSize: 15, display: "block", marginBottom: 12 }}>
-                  Party People <Badge count={participants.length} style={{ backgroundColor: "#00C2FF" }} />
-                </Text>
-              </div>
-
-              {/* Scrollable participants list */}
-              <div style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: "0 24px 24px 24px" }}>
-                {participants.length === 0 ? (
-                  <Text style={{ color: "rgba(255,255,255,0.3)" }}>No one here yet</Text>
-                ) : (
-                  participants.map((p) => (
-                    <div
-                      key={p.id}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 10,
-                        marginBottom: 8,
-                        padding: "6px 8px",
-                        borderRadius: 8,
-                        background: String(p.id) === String(userId) ? "rgba(0, 194, 255, 0.08)" : "transparent",
-                      }}
-                    >
-                      <Avatar size={28} icon={<UserOutlined />} style={{ background: "rgba(0, 194, 255, 0.3)", flexShrink: 0 }} />
-                      <Text style={{ color: "#FFFFFF", fontSize: 13 }}>
-                        {p.username}
-                        {String(p.id) === String(userId) && (
-                          <span style={{ color: "#00C2FF", marginLeft: 6, fontSize: 11 }}>
-                            {isAdmin ? "(host)" : "(you)"}
-                          </span>
-                        )}
-                      </Text>
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
-
-          </div>
-        </Layout.Sider>
+          onSkipSong={() => apiService.post(`/sessions/${sessionId}/songs/next`, {}).catch(console.error)}
+        />
       </Layout>
 
       <SongSearchDrawer

--- a/app/sessions/[sessionId]/page.tsx
+++ b/app/sessions/[sessionId]/page.tsx
@@ -98,7 +98,7 @@ const handleStartSession = async () => {
 
   if (openRound) {
     return (
-      <VotingPhase sessionId={sessionId} round={openRound} onRoundClosed={handleRoundClosed} />
+      <VotingPhase sessionId={sessionId} round={openRound} onRoundClosed={handleRoundClosed} currentSong={currentSong} />
     );
   }
 

--- a/app/sessions/[sessionId]/review/page.tsx
+++ b/app/sessions/[sessionId]/review/page.tsx
@@ -2,10 +2,10 @@
 
 import { useParams, useRouter } from "next/navigation";
 import { useSessionReview } from "@/hooks/useSessionReview";
+import { useSessionStatus } from "@/hooks/useSessionStatus";
 import useLocalStorage from "@/hooks/useLocalStorage";
-import Image from "next/image";
-import { Layout, Button, Typography, Spin } from "antd";
-import { ArrowLeftOutlined, TrophyOutlined } from "@ant-design/icons";
+import { Layout, Button, Typography, Spin, Avatar, Badge } from "antd";
+import { ArrowLeftOutlined, TrophyOutlined, UserOutlined } from "@ant-design/icons";
 
 const { Header, Content } = Layout;
 const { Text, Title } = Typography;
@@ -14,7 +14,9 @@ export default function SessionReviewPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
   const router = useRouter();
   const { clear: clearSessionId } = useLocalStorage<string>("sessionId", "");
+  const { value: userId } = useLocalStorage<string>("id", "");
   const { reviewSongs, isLoading } = useSessionReview(sessionId, true);
+  const { participants, isAdmin } = useSessionStatus(sessionId, userId ?? "");
 
   const handleBackToDashboard = () => {
     clearSessionId();
@@ -49,81 +51,116 @@ export default function SessionReviewPage() {
         <div style={{ width: 160 }} />
       </Header>
 
-      <Content style={{ padding: "40px 24px" }}>
-        <div style={{ maxWidth: 720, margin: "0 auto" }}>
+      <Layout style={{ background: "transparent", height: "calc(100vh - 56px)", overflow: "hidden" }}>
+        <Content style={{ padding: "40px 24px", overflowY: "auto" }}>
+          <div style={{ maxWidth: 720, margin: "0 auto" }}>
 
-          <div style={{ textAlign: "center", marginBottom: 40 }}>
-            <div style={{ fontSize: 52, marginBottom: 12 }}>🎉</div>
-            <Title level={2} style={{ color: "#FFFFFF", margin: 0 }}>
-              {"That's a wrap!"}
-            </Title>
-            <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 15 }}>
-              Here&apos;s everything that was performed tonight
-            </Text>
-          </div>
-
-          {isLoading ? (
-            <div style={{ display: "flex", justifyContent: "center", paddingTop: 40 }}>
-              <Spin size="large" />
+            <div style={{ textAlign: "center", marginBottom: 40 }}>
+              <div style={{ fontSize: 52, marginBottom: 12 }}>🎉</div>
+              <Title level={2} style={{ color: "#FFFFFF", margin: 0 }}>
+                {"That's a wrap!"}
+              </Title>
+              <Text style={{ color: "rgba(255,255,255,0.45)", fontSize: 15 }}>
+                Here&apos;s everything that was performed tonight
+              </Text>
             </div>
-          ) : reviewSongs.length === 0 ? (
-            <Text style={{ color: "rgba(255,255,255,0.3)", display: "block", textAlign: "center" }}>
-              No songs were played this session.
-            </Text>
-          ) : (
-            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-              {reviewSongs.map((song, index) => (
-                <div
-                  key={song.id}
-                  style={{
-                    background: "#1A1A2E",
-                    border: "1px solid rgba(255,255,255,0.08)",
-                    borderRadius: 12,
-                    padding: "14px 16px",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 14,
-                  }}
-                >
-                  <Text style={{ color: "rgba(255,255,255,0.3)", fontSize: 13, width: 24, textAlign: "right", flexShrink: 0 }}>
-                    {index + 1}
-                  </Text>
-                  {song.albumArt && (
-                    <Image
-                      src={song.albumArt}
-                      alt="album art"
-                      width={48}
-                      height={48}
-                      style={{ borderRadius: 6, flexShrink: 0 }}
-                    />
-                  )}
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ color: "#FFFFFF", fontSize: 14, fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                      {song.title}
+
+            {isLoading ? (
+              <div style={{ display: "flex", justifyContent: "center", paddingTop: 40 }}>
+                <Spin size="large" />
+              </div>
+            ) : reviewSongs.length === 0 ? (
+              <Text style={{ color: "rgba(255,255,255,0.3)", display: "block", textAlign: "center" }}>
+                No songs were played this session.
+              </Text>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+                {reviewSongs.map((song, index) => (
+                  <div
+                    key={song.id}
+                    style={{
+                      background: "#1A1A2E",
+                      border: "1px solid rgba(255,255,255,0.08)",
+                      borderRadius: 12,
+                      padding: "14px 16px",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 14,
+                    }}
+                  >
+                    <Text style={{ color: "rgba(255,255,255,0.3)", fontSize: 13, width: 24, textAlign: "right", flexShrink: 0 }}>
+                      {index + 1}
+                    </Text>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ color: "#FFFFFF", fontSize: 14, fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {song.title}
+                      </div>
+                      <div style={{ color: "rgba(255,255,255,0.5)", fontSize: 12 }}>
+                        {song.artist}
+                        {song.addedBy && (
+                          <span style={{ marginLeft: 8, color: "rgba(255, 45, 126, 0.7)" }}>
+                            · added by {song.addedBy.username}
+                          </span>
+                        )}
+                      </div>
                     </div>
-                    <div style={{ color: "rgba(255,255,255,0.5)", fontSize: 12 }}>
-                      {song.artist}
-                      {song.addedBy && (
-                        <span style={{ marginLeft: 8, color: "rgba(255, 45, 126, 0.7)" }}>
-                          · added by {song.addedBy.username}
-                        </span>
-                      )}
-                    </div>
+                    {song.currentVoteCount > 0 && (
+                      <div style={{ background: "rgba(255,45,126,0.1)", border: "1px solid rgba(255,45,126,0.25)", borderRadius: 12, padding: "2px 10px", flexShrink: 0 }}>
+                        <Text style={{ color: "#FF2D7E", fontSize: 12 }}>
+                          {song.currentVoteCount} {song.currentVoteCount === 1 ? "vote" : "votes"}
+                        </Text>
+                      </div>
+                    )}
                   </div>
-                  {song.currentVoteCount > 0 && (
-                    <div style={{ background: "rgba(255,45,126,0.1)", border: "1px solid rgba(255,45,126,0.25)", borderRadius: 12, padding: "2px 10px", flexShrink: 0 }}>
-                      <Text style={{ color: "#FF2D7E", fontSize: 12 }}>
-                        {song.currentVoteCount} {song.currentVoteCount === 1 ? "vote" : "votes"}
-                      </Text>
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
+                ))}
+              </div>
+            )}
 
-        </div>
-      </Content>
+          </div>
+        </Content>
+
+        <Layout.Sider
+          width={280}
+          style={{
+            background: "#1A1A2E",
+            borderLeft: "1px solid rgba(255, 255, 255, 0.1)",
+            overflowY: "auto",
+            padding: "24px",
+          }}
+        >
+          <Text style={{ color: "#FFFFFF", fontWeight: 600, fontSize: 15, display: "block", marginBottom: 16 }}>
+            Party People <Badge count={participants.length} style={{ backgroundColor: "#00C2FF" }} />
+          </Text>
+          {participants.length === 0 ? (
+            <Text style={{ color: "rgba(255,255,255,0.3)" }}>No participants</Text>
+          ) : (
+            participants.map((p) => (
+              <div
+                key={p.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  marginBottom: 8,
+                  padding: "6px 8px",
+                  borderRadius: 8,
+                  background: String(p.id) === String(userId) ? "rgba(0, 194, 255, 0.08)" : "transparent",
+                }}
+              >
+                <Avatar size={28} icon={<UserOutlined />} style={{ background: "rgba(0, 194, 255, 0.3)", flexShrink: 0 }} />
+                <Text style={{ color: "#FFFFFF", fontSize: 13 }}>
+                  {p.username}
+                  {String(p.id) === String(userId) && (
+                    <span style={{ color: "#00C2FF", marginLeft: 6, fontSize: 11 }}>
+                      {isAdmin ? "(host)" : "(you)"}
+                    </span>
+                  )}
+                </Text>
+              </div>
+            ))
+          )}
+        </Layout.Sider>
+      </Layout>
     </Layout>
   );
 }

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -70,6 +70,29 @@ a {
   transform: scale(0.9);
 }
 
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #FF2D7E transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 4px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: #FF2D7E;
+  border-radius: 4px;
+}
+
+.session-control-btn:hover {
+  background: rgba(255, 255, 255, 0.1) !important;
+  color: #FF2D7E !important;
+}
+
 .ant-alert-close-icon,
 .ant-alert-close-icon svg {
   color: #FF2D7E !important;

--- a/app/types/session.ts
+++ b/app/types/session.ts
@@ -1,5 +1,10 @@
 export type SessionStatus = "CREATED" | "ACTIVE" | "PAUSED" | "ENDED";
 
+export interface Participant {
+  id: number;
+  username: string;
+}
+
 export interface Session {
     id: string;
     gamePin: string;
@@ -7,7 +12,7 @@ export interface Session {
     description?: string;
     status?: SessionStatus;
     createdAt?: string;
-    admin?: { id: number; username: string };
-    participants?: { id: number; username: string }[];
+    admin?: Participant;
+    participants?: Participant[];
     requiresSongSelection?: boolean;
 }


### PR DESCRIPTION
Bugfix and refactor:

1) Play/Pause button state desync
2) Skip with single song in queue
3) Empty queue autoplay
4) Antd Tooltip deprecation warning (Tooltip)
5) Session paused, when admin leaves session
6) Display session status on session page
7) Dashboard → review page access
8) No Polling in useStatus Hook. When admin change session status, new status is braodcastet anywa<y, so Polling is not needed
9) Youtube player played last song, even when queue was empty
10) No Polling in useStatus Hook. When admin change session status, new status is braodcastet anywa<y, so Polling is not needed
11) Youtube player played last song, even when queue was empty
12) Added a Song leaderboard for the voting screen
13) Fixed winning screen (because removing of the sort function on the server caused the Frontend to show the wrong winning song)
14) added steps to join-session page
15) Refactored the SongSearch logic from drawer and searchcontent to a hook (useSongSearch) which is then called from both
16) removed Spotify stuff from dashboard
17) adjusted join-session with the setsessionid
18) Outsourcing waitinglobby from sessionpage in own component -> better overview
19) Outsourcing sidebar from sessionpage in own component -> better overview
20) adding scrollbardesig to globals.css
21) added hover design for Play button
22) removed unused AlbumArt -> is fetched directly via spotifyURL, but not from Backendserver
23) Participants are now shown in the review screen
24) Created Participant type